### PR TITLE
Added a Provider/connect style implementation

### DIFF
--- a/ActionSheetProvider.js
+++ b/ActionSheetProvider.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import ActionSheet from './ActionSheet';
+
+export default class ActionSheetProvider extends React.Component {
+  static childContextTypes = {
+    actionSheet: React.PropTypes.func,
+  };
+
+  getChildContext() {
+    return {
+      actionSheet: () => this._actionSheetRef,
+    };
+  }
+
+  render() {
+    return (
+      <ActionSheet ref={component => this._actionSheetRef = component}>
+        {React.Children.only(this.props.children)}
+      </ActionSheet>
+    );
+  }
+}

--- a/connectActionSheet.js
+++ b/connectActionSheet.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function connectActionSheet(WrappedComponent) {
+
+  const ConnectedActionSheet = (props, context) => {
+    return <WrappedComponent { ...props } actionSheet={context.actionSheet} />;
+  };
+
+  ConnectedActionSheet.contextTypes = {
+    actionSheet: React.PropTypes.func
+  };
+
+  return ConnectedActionSheet;
+}

--- a/index.js
+++ b/index.js
@@ -1,1 +1,6 @@
-module.exports = require('./ActionSheet');
+const exports = require('./ActionSheet');
+exports.ActionSheetProvider = require('./ActionSheetProvider').default;
+exports.connectActionSheet = require('./connectActionSheet').default;
+
+
+module.exports = exports;


### PR DESCRIPTION
Created a set of wrapper components to isolate the use of context, similar to Redux.
Tested on iOS, but not Android yet. 

If you think you'd accept a pull request like this, let me know and I'll go ahead and write up some documentation. Thanks

Usage basically looks like 
Provider:

```
import { ActionSheetProvider } from '@exponent/react-native-action-sheet';
...
  return (
    <ActionSheetProvider>
      <RootContainer>
    </ActionSheetProvider>
  );
```

connect:

```
import { connectActionSheet } from '@exponent/react-native-action-sheet';
...
_onOpenActionSheet() {
    // Same interface as https://facebook.github.io/react-native/docs/actionsheetios.html
    let options = ['Delete', 'Save', 'Cancel'];
    let destructiveButtonIndex = 0;
    let cancelButtonIndex = 2;
    this.props.actionSheet().showActionSheetWithOptions({
      options,
      cancelButtonIndex,
      destructiveButtonIndex,
    },
    (buttonIndex) => {
      // Do something here
    });
  }
...
export default connectActionSheet(Component);
```
